### PR TITLE
Compare Ints instead of String numbers

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,6 @@ function downloadAndPipeIntoStdout(url){
 }
 function getArrayOfEpisodes(source, input){
     const [ start, end ] = input.split(`-`)
-    if(start >= end) throw new Error('End point is smaller than start point')
+    if(parseInt(start, 10) >= parseInt(end, 10)) throw new Error('End point is smaller than start point')
     return Array(end-start+1).fill().map((x,i) => source[`Episode ${parseInt(start)+i}`])
 }


### PR DESCRIPTION
For the `getArrayOfEpisodes` function, when you compare String integers ("521"), it looks like it only takes in the first 2 digits if one has 3 digits. In my case I was trying to download `-e 76-136` and received a failure of:
```
error:  Error: End point is smaller than start point
    at getArrayOfEpisodes (C:\Users\JTRK\AppData\Roaming\npm\node_modules\twist-dl\index.js:126:28)
    at C:\Users\JTRK\AppData\Roaming\npm\node_modules\twist-dl\index.js:63:112
    at process._tickCallback (internal/process/next_tick.js:68:7)
```